### PR TITLE
Added Provider API server Network Policy to plugin reconcile funcs

### DIFF
--- a/datafoundation/templates_providerapiservernetworkpolicy.go
+++ b/datafoundation/templates_providerapiservernetworkpolicy.go
@@ -1,0 +1,54 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package datafoundation
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	netv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+var ProviderApiServerPort = intstr.FromInt(50051)
+var ProviderApiServerProtocol = corev1.ProtocolTCP
+
+var ProviderApiServerNetworkPolicyTemplate = netv1.NetworkPolicy{
+	Spec: netv1.NetworkPolicySpec{
+		Ingress: []netv1.NetworkPolicyIngressRule{
+			{
+				Ports: []netv1.NetworkPolicyPort{
+					{
+						Port:     &ProviderApiServerPort,
+						Protocol: &ProviderApiServerProtocol,
+					},
+				},
+			},
+		},
+		PolicyTypes: []netv1.PolicyType{
+			netv1.PolicyTypeIngress,
+		},
+		PodSelector: metav1.LabelSelector{
+			MatchExpressions: []metav1.LabelSelectorRequirement{
+				{
+					Key:      "app",
+					Operator: metav1.LabelSelectorOpIn,
+					Values: []string{
+						"ocsProviderApiServer",
+					},
+				},
+			},
+		},
+	},
+}


### PR DESCRIPTION
DataFoundation provider API server requires an ingress Network Policy so that DataFoundation Client clusters are able to connect to it.
This PR incorporates the change.