### PR TITLE
Fix the label in resource selector for prometheus

### DIFF
--- a/templates/prometheus.go
+++ b/templates/prometheus.go
@@ -30,7 +30,7 @@ import (
 // PrometheusTemplate is the template that serves as the base for the prometheus deployed by the operator
 var resourceSelector = metav1.LabelSelector{
 	MatchLabels: map[string]string{
-		"app": "managed-ocs",
+		"app": "managed-fusion-agent",
 	},
 }
 


### PR DESCRIPTION
Promtheus looks at resources that have `"app": "managed-fusion-agent"` label but it was not correctly configured so this PR fixes the issue.