### PR TITLE
Set reconciler storageCluster

### DIFF
--- a/controllers/datafoundation.go
+++ b/controllers/datafoundation.go
@@ -176,6 +176,7 @@ func (r *dataFoundationReconciler) reconcileStorageCluster() error {
 
 		// Prevent downscaling by comparing count from secret and count from storage cluster
 		r.setDeviceSetCount(ds, desiredDeviceSetCount, currDeviceSetCount)
+		r.storageCluster.Spec = sc.Spec
 
 		return nil
 	})


### PR DESCRIPTION
reconciler storageCluster spec is not being set so this patch will set it up to the correct configuration.