### PR TITLE
Add env var to ocs subscription to skip watching noobaa cr

### DIFF
--- a/controllers/managedfusionoffering_controller.go
+++ b/controllers/managedfusionoffering_controller.go
@@ -347,5 +347,11 @@ func pluginGetDesiredSubscriptionSpec(r *ManagedFusionOfferingReconciler) *opv1a
 	return &opv1a1.SubscriptionSpec{
 		Channel: "stable-4.12",
 		Package: "ocs-operator",
+		Config: opv1a1.SubscriptionConfig{
+			Env: []corev1.EnvVar{{
+				Name:  "SKIP_NOOBAA_CRD_WATCH",
+				Value: "true",
+			}},
+		},
 	}
 }


### PR DESCRIPTION
OCS Operator will skip watching the NooBaa CR if `SKIP_NOOBAA_CRD_WATCH` is set to `true`.
[Ref PR in OCS Operator](https://github.com/red-hat-storage/ocs-operator/pull/1972)