### PR TITLE
Add type gp3 to backing storage class

### DIFF
--- a/datafoundation/templates_storagecluster.go
+++ b/datafoundation/templates_storagecluster.go
@@ -101,6 +101,7 @@ var StorageClusterTemplate = ocsv1.StorageCluster{
 			Parameters: map[string]string{
 				"iops":       "12000",
 				"throughput": "250",
+				"type":       "gp3",
 			},
 		}},
 		StorageProfiles: []ocsv1.StorageProfile{{


### PR DESCRIPTION
We missed adding the type param in the backing storage class so this PR will add it.
If type is not mentioned as gp3 then the throughput is by default set to125