### PR TITLE
Add env var to ocs subscription to skip watching OB and OBC cr

### DIFF
--- a/controllers/managedfusionoffering_controller.go
+++ b/controllers/managedfusionoffering_controller.go
@@ -365,10 +365,16 @@ func pluginGetDesiredSubscriptionSpec(r *ManagedFusionOfferingReconciler) *opv1a
 			Channel: "stable-4.12",
 			Package: "ocs-operator",
 			Config: &opv1a1.SubscriptionConfig{
-				Env: []corev1.EnvVar{{
-					Name:  "SKIP_NOOBAA_CRD_WATCH",
-					Value: "true",
-				}},
+				Env: []corev1.EnvVar{
+					{
+						Name:  "SKIP_NOOBAA_CRD_WATCH",
+						Value: "true",
+					},
+					{
+						Name:  "ROOK_DISABLE_OBJECT_BUCKET_CLAIM",
+						Value: "true",
+					},
+				},
 			},
 		}
 	case v1alpha1.KindDataFoundationClient:


### PR DESCRIPTION
Rook provides an env var called `ROOK_DISABLE_OBJECT_BUCKET_CLAIM` to skip the watches on OB and OBC CRs
[Ref](https://github.com/rook/rook/commit/e87338fbc48ca564929feb5dc3097fdaf8f69e34)