### PR TITLE
Remove endpoint check and update operatorGroup for DFC offering

### DIFF
--- a/controllers/datafoundationclient.go
+++ b/controllers/datafoundationclient.go
@@ -2,7 +2,6 @@ package controllers
 
 import (
 	"fmt"
-	"net/url"
 	"strings"
 
 	opv1a1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
@@ -141,19 +140,11 @@ func (r *dataFoundationClientReconciler) reconcileStorageClient() error {
 		return fmt.Errorf("invalid provider endpoint, empty string")
 	}
 
-	providerEndpoint, err := url.ParseRequestURI(r.dataFoundationClientSpec.providerEndpoint)
-	if err != nil {
-		return fmt.Errorf("failed to parse %s, %v", r.dataFoundationClientSpec.providerEndpoint, err)
-	}
-	if providerEndpoint.Host == "" {
-		return fmt.Errorf("invalid provider endpoint %s, does not contain host", r.dataFoundationClientSpec.providerEndpoint)
-	}
-
 	if r.dataFoundationClientSpec.onboardingTicket == "" {
 		return fmt.Errorf("invalid onboarding ticket, empty string")
 
 	}
-	_, err = r.CreateOrUpdate(&r.storageClient, func() error {
+	_, err := r.CreateOrUpdate(&r.storageClient, func() error {
 		if err := r.own(&r.storageClient, true); err != nil {
 			return err
 		}

--- a/controllers/managedfusionoffering_controller.go
+++ b/controllers/managedfusionoffering_controller.go
@@ -337,9 +337,16 @@ func pluginSetupWatches(controllerBuilder *builder.Builder) {
 
 // This function is a placeholder for offering plugin integration
 func pluginGetDesiredOperatorGroupSpec(r *ManagedFusionOfferingReconciler) opv1.OperatorGroupSpec {
-	return opv1.OperatorGroupSpec{
-		TargetNamespaces: []string{r.namespace},
+	var desiredOperatorGroupSpec opv1.OperatorGroupSpec
+	switch r.managedFusionOffering.Spec.Kind {
+	case v1alpha1.KindDataFoundation:
+		desiredOperatorGroupSpec = opv1.OperatorGroupSpec{
+			TargetNamespaces: []string{r.namespace},
+		}
+	case v1alpha1.KindDataFoundationClient:
+		desiredOperatorGroupSpec = opv1.OperatorGroupSpec{}
 	}
+	return desiredOperatorGroupSpec
 }
 
 // This function is a placeholder for offering plugin integration


### PR DESCRIPTION
Remove storageProvider endpoint check
- loadbalancer IP that we get from provider storage cluster does not have a scheme
- parsing host from url return empty string if scheme is not mentioned
- parsing loadbalancer IP does not make sense because we not using a part of it
- instead we are using it as a whole

Update operatorGroup to allnamespace scope for DFC