### PR TITLE
Revert OCS Operator memory limit

### DIFF
--- a/datafoundation/resources.go
+++ b/datafoundation/resources.go
@@ -27,11 +27,11 @@ var resourceRequirements = map[string]corev1.ResourceRequirements{
 	"ocs-operator": {
 		Limits: corev1.ResourceList{
 			"cpu":    resource.MustParse("200m"),
-			"memory": resource.MustParse("800Mi"),
+			"memory": resource.MustParse("200Mi"),
 		},
 		Requests: corev1.ResourceList{
 			"cpu":    resource.MustParse("200m"),
-			"memory": resource.MustParse("800Mi"),
+			"memory": resource.MustParse("200Mi"),
 		},
 	},
 	"rook-ceph-operator": {


### PR DESCRIPTION
The memory limit of ocs-operator was increased in the past due to a known [bug](https://bugzilla.redhat.com/show_bug.cgi?id=2126626). 
The fix was introduced in v4.12 and the agent is using v4.12 so reverting the increase in memory limit. 
[PR](https://github.com/red-hat-storage/ocs-osd-deployer/pull/249) for memory bump in deployer