### PR TITLE
Add namespace selector in prometheus CR for certain resources and add missing labels on service monitor

### DIFF
--- a/controllers/managedfusion_controller.go
+++ b/controllers/managedfusion_controller.go
@@ -709,6 +709,7 @@ func (r *ManagedFusionReconciler) reconcileK8SMetricsServiceMonitor() error {
 		}
 		desired := templates.K8sMetricsServiceMonitorTemplate.DeepCopy()
 		r.k8sMetricsServiceMonitor.Spec = desired.Spec
+		utils.AddLabel(r.k8sMetricsServiceMonitor, monLabelKey, monLabelValue)
 		return nil
 	})
 	if err != nil {


### PR DESCRIPTION
namespace selector is added for
- prometheusRules
- serviceMonitor
- podMonitor

If the namespace selector is not passed then the own namespace is considered so now, Prometheus will select the resources having the label `"app": "managed-fusion-agent"` from all the namespaces.

Mon label was missing from this service monitor so Prometheus was not able to discover this service monitor which resulted in missing metrics.
