### PR TITLE
Update the mfo api to have all the fields as required

### DIFF
--- a/api/v1alpha1/managedfusionoffering_types.go
+++ b/api/v1alpha1/managedfusionoffering_types.go
@@ -30,9 +30,9 @@ const (
 
 // ManagedFusionOfferingSpec defines the desired state of ManagedFusionOffering
 type ManagedFusionOfferingSpec struct {
-	Kind    OfferingKind `json:"kind,omitempty"`
-	Release string       `json:"release,omitempty"`
-	Config  string       `json:"config,omitempty"`
+	Kind    OfferingKind `json:"kind"`
+	Release string       `json:"release"`
+	Config  string       `json:"config"`
 }
 
 // ManagedFusionOfferingStatus defines the observed state of ManagedFusionOffering

--- a/config/crd/bases/misf.ibm.com_managedfusionofferings.yaml
+++ b/config/crd/bases/misf.ibm.com_managedfusionofferings.yaml
@@ -45,6 +45,10 @@ spec:
                 type: string
               release:
                 type: string
+            required:
+            - config
+            - kind
+            - release
             type: object
           status:
             description: ManagedFusionOfferingStatus defines the observed state of


### PR DESCRIPTION
Remove omitempty from all the fields to make them required. When we apply the CR for the offering with one or more fields not there, it will fail due to missing fields.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2208167