### PR TITLE
Handle 1-4TiB provider config and upscaling

### DIFF
--- a/controllers/datafoundation.go
+++ b/controllers/datafoundation.go
@@ -283,7 +283,7 @@ func (r *dataFoundationReconciler) reconcileStorageCluster() error {
 		}
 
 		// Convert the desired size to the device set count based on the underlying OSD size
-		desiredDeviceSetCount := int(math.Ceil(UsableCapacityInTiB.AsApproximateFloat64() / desiredOSDSizeInTiB.AsApproximateFloat64()))
+		desiredDeviceSetCount := int(math.Ceil(float64(UsableCapacityInTiB.ScaledValue(resource.Tera)) / float64(desiredOSDSizeInTiB.ScaledValue(resource.Tera))))
 
 		// Get the desired storage device set from storage cluster template
 		sc := templates.StorageClusterTemplate.DeepCopy()

--- a/datafoundation/templates/storagecluster.go
+++ b/datafoundation/templates/storagecluster.go
@@ -25,11 +25,9 @@ import (
 // StorageClusterTemplate is the template that serves as the base for the storage clsuter deployed by the operator
 
 const (
-	OSDSizeUpperBoundInTiBUnscaled = 4398046511104
-	backingStorageClassName        = "default-ocs-storage-class"
+	OSDSizeUpperBoundInTiB  = 4
+	backingStorageClassName = "default-ocs-storage-class"
 )
-
-var OSDSizeUpperBoundInTib = resource.NewQuantity(OSDSizeUpperBoundInTiBUnscaled, resource.BinarySI)
 
 var commonTSC corev1.TopologySpreadConstraint = corev1.TopologySpreadConstraint{
 	MaxSkew:           1,

--- a/datafoundation/templates/storagecluster.go
+++ b/datafoundation/templates/storagecluster.go
@@ -27,8 +27,9 @@ import (
 // StorageClusterTemplate is the template that serves as the base for the storage clsuter deployed by the operator
 
 const (
-	OSDSizeInTiB            = 4
-	backingStorageClassName = "default-ocs-storage-class"
+	OSDSizeInTiB                  = 1
+	VerticalScalerUpperBoundInTiB = 4
+	backingStorageClassName       = "default-ocs-storage-class"
 )
 
 var commonTSC corev1.TopologySpreadConstraint = corev1.TopologySpreadConstraint{

--- a/datafoundation/templates/storagecluster.go
+++ b/datafoundation/templates/storagecluster.go
@@ -13,8 +13,6 @@ limitations under the License.
 package templates
 
 import (
-	"fmt"
-
 	df "github.com/red-hat-storage/managed-fusion-agent/datafoundation"
 	"github.com/red-hat-storage/managed-fusion-agent/utils"
 	ocsv1 "github.com/red-hat-storage/ocs-operator/api/v1"
@@ -27,10 +25,11 @@ import (
 // StorageClusterTemplate is the template that serves as the base for the storage clsuter deployed by the operator
 
 const (
-	OSDSizeInTiB                  = 1
-	VerticalScalerUpperBoundInTiB = 4
-	backingStorageClassName       = "default-ocs-storage-class"
+	OSDSizeUpperBoundInTiBUnscaled = 4398046511104
+	backingStorageClassName        = "default-ocs-storage-class"
 )
+
+var OSDSizeUpperBoundInTib = resource.NewQuantity(OSDSizeUpperBoundInTiBUnscaled, resource.BinarySI)
 
 var commonTSC corev1.TopologySpreadConstraint = corev1.TopologySpreadConstraint{
 	MaxSkew:           1,
@@ -139,9 +138,7 @@ var StorageClusterTemplate = ocsv1.StorageCluster{
 					},
 					VolumeMode: utils.ToPointer(corev1.PersistentVolumeBlock),
 					Resources: corev1.ResourceRequirements{
-						Requests: corev1.ResourceList{
-							"storage": resource.MustParse(fmt.Sprintf("%dTi", OSDSizeInTiB)),
-						},
+						Requests: corev1.ResourceList{},
 					},
 				},
 			},


### PR DESCRIPTION
Resolves [Faas-44](https://jsw.ibm.com/browse/FAAS-44), [Faas-45](https://jsw.ibm.com/browse/FAAS-45):

- Adds support for `UsableCapacityInTiB` config knob with values 1-4TiB (units included)
- Performs up-scaling and prevents down-scaling

TODOs:
- [ ] Check regarding optimal perf of different setups of {capacity, OSD size} combos 
- [x] Check use case of non-integer `UsableCapacityInTiB` is handled correctly
- [x] Test manually

![image](https://github.com/red-hat-storage/managed-fusion-agent/assets/132667934/d8fa31c3-fc0d-4d70-b862-26e9c35a3ee7)



